### PR TITLE
Automatic creation of a datasource in grafana

### DIFF
--- a/jobs/grafana/monit
+++ b/jobs/grafana/monit
@@ -3,3 +3,5 @@ check process grafana
   start program "/var/vcap/jobs/grafana/bin/grafana_ctl start"
   stop program "/var/vcap/jobs/grafana/bin/grafana_ctl stop"
   group vcap
+check file datasource_marker with path /var/vcap/sys/run/grafana/datasource_created
+  if does not exist then exec /var/vcap/jobs/grafana/bin/create_datasource

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -3,6 +3,7 @@ name: grafana
 
 templates:
   grafana_ctl: bin/grafana_ctl
+  create_datasource.erb: bin/create_datasource
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt
@@ -125,3 +126,26 @@ properties:
   grafana.auth.google.allowed_email_domains:
     description: "E-mail address domains to allow. If empty, all are allowed."
     default: []
+
+  grafana.datasource.name:
+    description: "The name of the datasource that points to the metrics database"
+    default: influxdb
+
+  grafana.datasource.database_type:
+    description: "The type of the metrics database"
+    default: influbxdb_08
+
+  grafana.datasource.url:
+    description: "The url of the metrics database"
+
+  grafana.datasource.user:
+    description: "The user name for the metrics database"
+    default: metrics-user
+
+  grafana.datasource.password:
+    description: "The password for the metrics database"
+    default: metrics-password
+
+  grafana.datasource.database_name:
+    description: "The name of the metrics database"
+    default: metrics

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -127,6 +127,9 @@ properties:
     description: "E-mail address domains to allow. If empty, all are allowed."
     default: []
 
+  grafana.datasource.url:
+    description: "The url of the metrics database. No datasource will be created if this is set to nil."
+
   grafana.datasource.name:
     description: "The name of the datasource that points to the metrics database"
     default: influxdb
@@ -134,9 +137,6 @@ properties:
   grafana.datasource.database_type:
     description: "The type of the metrics database"
     default: influbxdb_08
-
-  grafana.datasource.url:
-    description: "The url of the metrics database"
 
   grafana.datasource.user:
     description: "The user name for the metrics database"

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -132,20 +132,15 @@ properties:
 
   grafana.datasource.name:
     description: "The name of the datasource that points to the metrics database"
-    default: influxdb
 
   grafana.datasource.database_type:
     description: "The type of the metrics database"
-    default: influbxdb_08
 
   grafana.datasource.user:
     description: "The user name for the metrics database"
-    default: metrics-user
 
   grafana.datasource.password:
     description: "The password for the metrics database"
-    default: metrics-password
 
   grafana.datasource.database_name:
     description: "The name of the metrics database"
-    default: metrics

--- a/jobs/grafana/templates/create_datasource.erb
+++ b/jobs/grafana/templates/create_datasource.erb
@@ -2,6 +2,7 @@
 
 LOG_DIR=/var/vcap/sys/log/grafana
 MARKERFILE=/var/vcap/sys/run/grafana/datasource_created
+<% if_p("grafana.datasource.url") do |datasource_url| %>
 URL="http://<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>@localhost:<%= p("grafana.listen_port") %>/api/datasources"
 DATASOURCE_NAME="<%= p("grafana.datasource.name") %>"
 
@@ -9,7 +10,7 @@ DATA='
 {"name":"'"${DATASOURCE_NAME}"'",
  "type":"<%= p("grafana.datasource.database_type") %>",
  "access":"proxy",
- "url":"<%= p("grafana.datasource.url") %>",
+ "url":"<%= datasource_url %>",
  "password":"<%= p("grafana.datasource.password") %>",
  "user":"<%= p("grafana.datasource.user") %>",
  "database":"<%= p("grafana.datasource.database_name") %>",
@@ -23,3 +24,6 @@ else
     echo "Created datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
   fi
 fi
+<% end.else do %>
+echo "No automatic datasource creation requested" > ${MARKERFILE}
+<% end %>

--- a/jobs/grafana/templates/create_datasource.erb
+++ b/jobs/grafana/templates/create_datasource.erb
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+LOG_DIR=/var/vcap/sys/log/grafana
+MARKERFILE=/var/vcap/sys/run/grafana/datasource_created
+URL="http://<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>@localhost:<%= p("grafana.listen_port") %>/api/datasources"
+DATASOURCE_NAME="<%= p("grafana.datasource.name") %>"
+
+DATA='
+{"name":"'"${DATASOURCE_NAME}"'",
+ "type":"<%= p("grafana.datasource.database_type") %>",
+ "access":"proxy",
+ "url":"<%= p("grafana.datasource.url") %>",
+ "password":"<%= p("grafana.datasource.password") %>",
+ "user":"<%= p("grafana.datasource.user") %>",
+ "database":"<%= p("grafana.datasource.database_name") %>",
+ "basicAuth":false
+}'
+
+if curl -ivf "$URL" | grep '"name":"'"${DATASOURCE_NAME}"'"' ; then
+  echo "Datasource ${DATASOURCE_NAME} exists, checked at $(date)" > ${MARKERFILE}
+else
+  if curl -ivf -X POST "$URL" -H 'Content-Type: application/json' -d "${DATA}" &> ${LOG_DIR}/datasource_create.log ; then
+    echo "Created datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
+  fi
+fi

--- a/jobs/grafana/templates/create_datasource.erb
+++ b/jobs/grafana/templates/create_datasource.erb
@@ -2,7 +2,10 @@
 
 LOG_DIR=/var/vcap/sys/log/grafana
 MARKERFILE=/var/vcap/sys/run/grafana/datasource_created
+
 <% if_p("grafana.datasource.url") do |datasource_url| %>
+exec &>> ${LOG_DIR}/datasource_create.log
+
 URL="http://<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>@localhost:<%= p("grafana.listen_port") %>/api/datasources"
 DATASOURCE_NAME="<%= p("grafana.datasource.name") %>"
 
@@ -17,10 +20,18 @@ DATA='
  "basicAuth":false
 }'
 
-if curl -ivf "$URL" | grep '"name":"'"${DATASOURCE_NAME}"'"' ; then
-  echo "Datasource ${DATASOURCE_NAME} exists, checked at $(date)" > ${MARKERFILE}
+# If we had jq, this is what the query would look like:
+#DATASOURCE_ID=$(curl -s "${URL}" | jq '.[] | select(.name == "'"${DATASOURCE_NAME}"'") | .id ')
+# Instead we have to call sed to the rescue:
+DATASOURCE_ID=$(curl -s "${URL}" | sed -n 's/[^"]*"id":\([0-9]*\),.*"name":"'"${DATASOURCE_NAME}"'".*$/\1/p' )
+echo "Datasource '${DATASOURCE_NAME}' has id '${DATASOURCE_ID}'"
+
+if [ -n "${DATASOURCE_ID}" ]; then
+  if curl -ivf -X PUT "${URL}/${DATASOURCE_ID}" -H 'Content-Type: application/json' -d "${DATA}" ; then
+    echo "Updated datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
+  fi
 else
-  if curl -ivf -X POST "$URL" -H 'Content-Type: application/json' -d "${DATA}" &> ${LOG_DIR}/datasource_create.log ; then
+  if curl -ivf -X POST "${URL}" -H 'Content-Type: application/json' -d "${DATA}" ; then
     echo "Created datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
   fi
 fi

--- a/jobs/grafana/templates/create_datasource.erb
+++ b/jobs/grafana/templates/create_datasource.erb
@@ -6,8 +6,9 @@ MARKERFILE=/var/vcap/sys/run/grafana/datasource_created
 <% if_p("grafana.datasource.url") do |datasource_url| %>
 exec &>> ${LOG_DIR}/datasource_create.log
 
-URL="http://<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>@localhost:<%= p("grafana.listen_port") %>/api/datasources"
-DATASOURCE_NAME="<%= p("grafana.datasource.name") %>"
+URL='<%= p("grafana.ssl.cert", nil) ? "https" : "http" %>://127.0.0.1:<%= p("grafana.listen_port") %>/api/datasources'
+CREDENTIALS='<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>'
+DATASOURCE_NAME='<%= p("grafana.datasource.name") %>'
 
 DATA='
 {"name":"'"${DATASOURCE_NAME}"'",
@@ -21,17 +22,17 @@ DATA='
 }'
 
 # If we had jq, this is what the query would look like:
-#DATASOURCE_ID=$(curl -s "${URL}" | jq '.[] | select(.name == "'"${DATASOURCE_NAME}"'") | .id ')
+#DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | jq '.[] | select(.name == "'"${DATASOURCE_NAME}"'") | .id ')
 # Instead we have to call sed to the rescue:
-DATASOURCE_ID=$(curl -s "${URL}" | sed -n 's/[^"]*"id":\([0-9]*\),.*"name":"'"${DATASOURCE_NAME}"'".*$/\1/p' )
+DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | sed -n 's/[^"]*"id":\([0-9]*\),.*"name":"'"${DATASOURCE_NAME}"'".*$/\1/p' )
 echo "Datasource '${DATASOURCE_NAME}' has id '${DATASOURCE_ID}'"
 
 if [ -n "${DATASOURCE_ID}" ]; then
-  if curl -ivf -X PUT "${URL}/${DATASOURCE_ID}" -H 'Content-Type: application/json' -d "${DATA}" ; then
+  if curl -u "${CREDENTIALS}" -kivf -X PUT "${URL}/${DATASOURCE_ID}" -H 'Content-Type: application/json' -d "${DATA}" ; then
     echo "Updated datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
   fi
 else
-  if curl -ivf -X POST "${URL}" -H 'Content-Type: application/json' -d "${DATA}" ; then
+  if curl -u "${CREDENTIALS}" -kivf -X POST "${URL}" -H 'Content-Type: application/json' -d "${DATA}" ; then
     echo "Created datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
   fi
 fi


### PR DESCRIPTION
This uses the /api/datasources endpoint of grafana to create a datasource automatically as soon as grafana becomes available. monit will retry this until it succeeds.
