### PR TITLE
Explicitly set plugin directory

### DIFF
--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -16,10 +16,11 @@ data = /var/vcap/store/grafana
 # Directory where grafana can store logs
 #
 logs = /var/vcap/sys/log/grafana
+
 #
 # Directory where grafana will automatically scan and look for plugins
 #
-;plugins = /var/lib/grafana/plugins
+plugins = /var/vcap/store/grafana/plugins
 
 #
 #################################### Server ####################################


### PR DESCRIPTION
Hi,

If the property paths.plugins is not explicitly set, it will be overridden by the default ([data/plugins](https://github.com/grafana/grafana/blob/master/conf/defaults.ini#L21)). In this case relative to the monit working directory (/etc/sv/monit).

Best Regards,
@philippthun and @achawki
