### PR TITLE
Supply dashboards as minified JSON via properties

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -5,6 +5,7 @@ templates:
   grafana_ctl: bin/grafana_ctl
   post-start: bin/post-start
   create-update-datasources.erb: bin/create-update-datasources
+  create-update-dashboards.erb: bin/create-update-dashboards
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt
@@ -157,6 +158,14 @@ properties:
         user: admin
         password: admin123
         database_name: metrics
+
+  grafana.dashboards:
+    description: |
+      List of grafana dasboards, converted to YAML
+    example: |
+      - name: frontend (without extension)
+        content: <minified JSON content>
+    default: []
 
   grafana.auth.proxy.enabled:
     description: "Handle authentication in a http reverse proxy"

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -270,5 +270,5 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 
 ;#################################### Dashboard JSON files ##########################
 [dashboards.json]
-;enabled = false
-;path = /var/lib/grafana/dashboards
+enabled = true
+path = /var/vcap/store/grafana/dashboards

--- a/jobs/grafana/templates/create-update-dashboards.erb
+++ b/jobs/grafana/templates/create-update-dashboards.erb
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DASHBOARDS_DIR="/var/vcap/store/grafana/dashboards"
+LOG_DIR=/var/vcap/sys/log/grafana
+
+exec &>> ${LOG_DIR}/create-update-dashboards.log
+
+echo Create ${DASHBOARDS_DIR} directory
+mkdir -p ${DASHBOARDS_DIR}
+
+echo Delete old dashboards from ${DASHBOARDS_DIR}
+rm -f ${DASHBOARDS_DIR}/*
+
+<%
+  dashboards = p("grafana.dashboards")
+%>
+
+<% dashboards.each do |dashboard| %>
+dashboard_file="${DASHBOARDS_DIR}/<%= dashboard['name'] %>.json"
+
+echo Create ${dashboard_file}
+
+cat > "${dashboard_file}" <<'EOF'
+<%= dashboard['content'] %>
+EOF
+<% end %>
+
+<% if dashboards.empty? then %>
+echo "No automatic dashboard creation requested"
+<% end %>

--- a/jobs/grafana/templates/post-start
+++ b/jobs/grafana/templates/post-start
@@ -2,3 +2,6 @@
 
 echo "[$(date)] Calling 'create-update-datasources' ..."
 $(dirname $0)/create-update-datasources
+
+echo "[$(date)] Calling 'create-update-dashboards' ..."
+$(dirname $0)/create-update-dashboards


### PR DESCRIPTION
## Why

We want to be able to deploy Grafana with dashboard configuration files (JSON files) supplied via the manifest. This will allow this release to remain generic and change dashboards more easily.
## What

The changes introduced enable dashboard configuration and add a post-start hook to take minified JSON from manifest properties and put them into files.
## How to review
- deploy using a manifest containing `properties.grafana.dashboards`, which is a list of objects containing a `name` field, which is the name of the dashboard, and a `content` field, which is a Grafana dashboard stored as minified JSON.
- Implementors will require their own mechanism for supplying the JSON and verifying it does not break the integrity of their manifest.
