### PR TITLE
Pass through arbitrary datasource parameters.

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -129,35 +129,22 @@ properties:
     description: "E-mail address domains to allow. If empty, all are allowed."
     default: []
 
-  grafana.datasource.url:
-    description: "The url of the metrics database. No datasource will be created if this is set to nil."
-
-  grafana.datasource.name:
-    description: "The name of the datasource that points to the metrics database"
-
-  grafana.datasource.database_type:
-    description: "The type of the metrics database"
-
-  grafana.datasource.user:
-    description: "The user name for the metrics database"
-
-  grafana.datasource.password:
-    description: "The password for the metrics database"
-
-  grafana.datasource.database_name:
-    description: "The name of the metrics database"
+  grafana.datasource:
+    description: "Grafana datasource; see http://docs.grafana.org/http_api/data_source/ for details"
 
   grafana.datasources:
     description: |
-      * If you want to configure multiple datasources, you can define an array of hashes here. Each hash must have 'name', 'url', 'database_type', 'user', 'password' and 'database_name' defined.
+      * If you want to configure multiple datasources, you can define an array of hashes here. Each hash must have 'name', 'url', 'type', 'user', 'password' and 'database' defined.
       * These datasources will be created in addition to the datasource defined in 'grafana.datasource'. The latter property is for backwards compatibility.
+      * See http://docs.grafana.org/http_api/data_source/ for details
     example: |
       - name: influxdb
         url: http://1.2.3.4:8086
-        database_type: influxdb
+        type: influxdb
         user: admin
         password: admin123
-        database_name: metrics
+        database: metrics
+    default: []
 
   grafana.dashboards:
     description: |

--- a/jobs/grafana/templates/create-update-datasources.erb
+++ b/jobs/grafana/templates/create-update-datasources.erb
@@ -2,25 +2,6 @@
 
 LOG_DIR=/var/vcap/sys/log/grafana
 
-<%
-  datasources = Array.new
-
-  if_p("grafana.datasources") do |dss|
-    datasources = dss
-  end
-
-  if_p("grafana.datasource.url") do |ds|
-    datasources << {
-      "url" => p("grafana.datasource.url"),
-      "name" => p("grafana.datasource.name"),
-      "database_type" => p("grafana.datasource.database_type"),
-      "user" => p("grafana.datasource.user"),
-      "password" => p("grafana.datasource.password"),
-      "database_name" => p("grafana.datasource.database_name")
-    }
-  end
-%>
-
 exec &>> ${LOG_DIR}/create-update-datasources.log
 
 URL='<%= p("grafana.ssl.cert", nil) ? "https" : "http" %>://127.0.0.1:<%= p("grafana.listen_port") %>/api/datasources'
@@ -47,21 +28,28 @@ then
   exit 1
 fi
 
+<%
+  require 'json'
+  datasources = p('grafana.datasources')
+  if_p('grafana.datasource') do |datasource|
+    datasources << p('grafana.datasource')
+  end
+  datasources = datasources.map do |datasource|
+    {
+      'access' => 'proxy',
+      'basicAuth' => false,
+      'database' => datasource.delete('database_name'),
+      'type' => datasource.delete('database_type'),
+    }.merge(datasource)
+  end
+%>
+
 <% datasources.each do |datasource| %>
 echo -e "\nCreating/Updating datasource '<%= datasource['name'] %>' at $(date)"
 
 DATASOURCE_NAME='<%= datasource['name'] %>'
 
-DATA='
-{"name":"'"${DATASOURCE_NAME}"'",
- "type":"<%= datasource['database_type'] %>",
- "access":"proxy",
- "url":"<%= datasource['url'] %>",
- "password":"<%= datasource['password'] %>",
- "user":"<%= datasource['user'] %>",
- "database":"<%= datasource['database_name'] %>",
- "basicAuth":false
-}'
+DATA='<%= JSON.dump(datasource) %>'
 
 # If we had jq, this is what the query would look like:
 #DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | jq '.[] | select(.name == "'"${DATASOURCE_NAME}"'") | .id ')


### PR DESCRIPTION
This patch passes datasource parameters directly to grafana rather than using different parameter names in the BOSH properties (database_type, database_name) and mapping to grafana properties (type, name). This simplifies the code and allows users to specify arbitrary parameters that aren't listed in `spec`, such as `isDefault`. For backwards, compatibility, `database_name` and `database_type` are still supported if specified.
