### PR TITLE
Implement logic to send service logs to syslog

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -165,3 +165,7 @@ properties:
 
   grafana.auth.proxy.auto_sign_up:
     description: "Enable sign up of users who do not exist in Grafana DB"
+
+  grafana.log_to_syslog:
+    description: Set this to True to enable logging to syslog.
+    default: False

--- a/jobs/grafana/templates/grafana_ctl
+++ b/jobs/grafana/templates/grafana_ctl
@@ -24,13 +24,21 @@ case $1 in
     mkdir -p $PACKAGE_DIR/data/log
     chown vcap:vcap $PACKAGE_DIR/data/log
 
+<% if p('grafana.log_to_syslog') %>
+    exec chpst -u vcap:vcap $PACKAGE_DIR/bin/grafana-server \
+      -config=/var/vcap/jobs/grafana/config/config.ini \
+      -homepath=$PACKAGE_DIR \
+      -pidfile=$PIDFILE \
+      1> >( tee -a $LOG_DIR/stdout.log | logger -t vcap.grafana.stdout ) \
+      2> >( tee -a $LOG_DIR/stderr.log | logger -t vcap.grafana.stderr )
+<% else %>
     exec chpst -u vcap:vcap $PACKAGE_DIR/bin/grafana-server \
       -config=/var/vcap/jobs/grafana/config/config.ini \
       -homepath=$PACKAGE_DIR \
       -pidfile=$PIDFILE \
       1>>$LOG_DIR/stdout.log \
       2>>$LOG_DIR/stderr.log
-
+<% end %>
     ;;
 
   stop)


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the _log to stdout and redirect  to `logger` pattern_ whenever is possible.
## Implementation in grafana release

We will implement this for the grafana job.

We add a property `grafana.log_to_syslog`. When true, we redirect the stdout and stderr in the ctl script into syslog following the standard vcap pattern, in addition to files.
## How to review?

Enable the `grafana.log_to_syslog` and deploy. Logs should be sent to syslog. If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.
## Open questions
- Is OK to add a specific property to enable grafana logs to syslog? or should this be enabled by default?
- Is the tag `vcap.grafana.*` the most appropriate one? 
- `tee` and `logger` run as root. Is that fine?
