### PR TITLE
support cloudwatch data source in grafana

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -9,6 +9,7 @@ templates:
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt
+  credentials: home/.aws/credentials
 
 packages:
 - grafana
@@ -174,3 +175,15 @@ properties:
 
   grafana.auth.proxy.auto_sign_up:
     description: "Enable sign up of users who do not exist in Grafana DB"
+
+  grafana.aws.aws_access_key_id:
+    description: "access key for AWS cloudwatch data source"
+    default: ""
+
+  grafana.aws.aws_secret_access_key:
+    description: "secret access key for AWS cloudwatch data source"
+    default: ""
+
+  grafana.aws.region:
+    description: "region for AWS cloudwatch data source"
+    default: ""

--- a/jobs/grafana/templates/credentials
+++ b/jobs/grafana/templates/credentials
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id = <%= p("grafana.aws.aws_access_key_id") %>
+aws_secret_access_key = <%= p("grafana.aws.aws_secret_access_key") %>
+region = <%= p("grafana.aws.region") %>

--- a/jobs/grafana/templates/grafana_ctl
+++ b/jobs/grafana/templates/grafana_ctl
@@ -7,6 +7,7 @@ LOG_DIR=/var/vcap/sys/log/grafana
 STORE_DIR=/var/vcap/store/grafana
 PACKAGE_DIR=/var/vcap/packages/grafana
 PIDFILE=$RUN_DIR/pid
+HOME_DIR=/var/vcap/jobs/grafana/home
 
 source $PACKAGE_DIR/pid_utils.sh
 
@@ -26,7 +27,7 @@ case $1 in
 
     setcap cap_net_bind_service=+ep $PACKAGE_DIR/bin/grafana-server
 
-    exec chpst -u vcap:vcap $PACKAGE_DIR/bin/grafana-server \
+    exec chpst -u vcap:vcap env HOME=$HOME_DIR $PACKAGE_DIR/bin/grafana-server \
       -config=/var/vcap/jobs/grafana/config/config.ini \
       -homepath=$PACKAGE_DIR \
       -pidfile=$PIDFILE \


### PR DESCRIPTION
as discussed in issue #12 

grafana cloudwatch data source is looking for aws credentials in `$HOME/.aws/credentials`.
this PR creates the credentials file in `/var/vcap/jobs/grafana/home/.aws/credentials` containing AWS keys and set $HOME env-var for the grafana-server process launched by the `chpst` command.

I've tested it locally in bosh-lite and works fine.
