### PR TITLE
Reset grafana password via grafana-cli

### DIFF
--- a/jobs/grafana/templates/post-start
+++ b/jobs/grafana/templates/post-start
@@ -5,3 +5,11 @@ $(dirname $0)/create-update-datasources
 
 echo "[$(date)] Calling 'create-update-dashboards' ..."
 $(dirname $0)/create-update-dashboards
+
+echo "[$(date)] Updating password for admin user"
+(
+cd $(dirname $0)/..
+mkdir conf
+ln -s $(pwd)/config/config.ini $(pwd)/conf/defaults.ini
+/var/vcap/packages/grafana/bin/grafana-cli admin reset-admin-password <%= p("grafana.admin_password") %>
+)


### PR DESCRIPTION
## What
The `grafana-cli admin` command was introduced in v 4.1 and allows to
change admin user password via cli.

This will allow to set new password in the manifest and rotate it during deployment.

Unfortunatelly `grafana-cli` is a little bit silly now and can only read config from `$WORKING_DIR/conf/defaults.ini` and as we have grfana.db in `/var/vcap/store/grafana` we need to point it there somehow.

**NOTE** This requires grafana 4.1 so version bump is necessary. 

## How to test 
- Deploy grafana and check if you can login to UI as admin
- change password in the manifest 
- redeploy and verify that admin password to UI has been changed 