### PR TITLE
Update Grafana to v4.1.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,0 @@
-grafana/grafana-4.0.0-1480439068.linux-x64.tar.gz:
-  size: 42173882
-  object_id: 9b0251c2-8692-41c9-77c9-64add0a09c24
-  sha: 1eec915c5d2e199f6704b15c4a2f5610bc1cb425

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -174,3 +174,7 @@ properties:
 
   grafana.auth.proxy.auto_sign_up:
     description: "Enable sign up of users who do not exist in Grafana DB"
+
+  grafana.snapshots.external_enabled:
+    description: "Enable external snapshots sharing (to snapshot.raintank.io)"
+    default: true

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -6,6 +6,9 @@
 # possible values : production, development
 ; app_mode = production
 
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+; instance_name = ${HOSTNAME}
+
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
@@ -42,7 +45,8 @@ http_port = <%= p("grafana.listen_port") %>
 ;enforce_domain = false
 
 <% if_p("grafana.root_url") do |root_url| %>
-# The full public facing url
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
 root_url = <%= root_url %>
 <% end %>
 
@@ -63,12 +67,20 @@ cert_key = /var/vcap/jobs/grafana/config/ssl.key
 
 #################################### Database ####################################
 [database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as seperate properties or as on string using the url propertie.
+
 # Either "mysql", "postgres" or "sqlite3", it's your choice
 type = sqlite3
 ;host = 127.0.0.1:3306
 ;name = grafana
 ;user = root
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
 ;password =
+
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+;url =
 
 # For "postgres" only, either "disable", "require" or "verify-full"
 ;ssl_mode = disable
@@ -135,8 +147,20 @@ admin_password = <%= p("grafana.admin_password") %>
 # disable gravatar profile images
 ;disable_gravatar = false
 
-# data source proxy whitelist (ip_or_domain:port seperated by spaces)
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
 ;data_source_proxy_whitelist =
+
+[snapshots]
+# snapshot sharing options
+;external_enabled = true
+;external_snapshot_url = https://snapshots-origin.raintank.io
+;external_snapshot_name = Publish to snapshot.raintank.io
+
+# remove expired snapshot
+;snapshot_remove_expired = true
+
+# remove snapshots after 90 days
+;snapshot_TTL_days = 90
 
 #################################### Users ####################################
 [users]
@@ -154,6 +178,13 @@ auto_assign_org_role = <%= p("grafana.users.auto_assign_organization_role") %>
 
 # Background text for the user field on the login page
 ;login_hint = email or username
+
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
+[auth]
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+;disable_login_form = false
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
@@ -196,6 +227,29 @@ api_url = <%= p("grafana.auth.google.api_url") %>
 allowed_domains = <%= p("grafana.auth.google.allowed_email_domains").join(" ") %>
 <% end %>
 
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+;enabled = false
+;name = OAuth
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://foo.bar/login/oauth/authorize
+;token_url = https://foo.bar/login/oauth/access_token
+;api_url = https://foo.bar/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Grafana.net Auth ####################
+[auth.grafananet]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;allowed_organizations =
+
 <% if_p("grafana.auth.proxy.enabled") do %>
 #################################### Auth Proxy ##########################
 [auth.proxy]
@@ -213,6 +267,7 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 [auth.ldap]
 ;enabled = false
 ;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
 
 #################################### SMTP / Emailing ##########################
 [smtp]
@@ -231,22 +286,30 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 #################################### Logging ##########################
 [log]
 # Either "console", "file", "syslog". Default is console and  file
-# Use comma to separate multiple modes, e.g. "console, file"
-;mode = console, file
+# Use space to separate multiple modes, e.g. "console file"
+;mode = console file
 
-# Buffer length of channel, keep it as it is if you don't know what it is.
-;buffer_len = 10000
+# Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
+;level = info
 
-# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
-;level = Info
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+;filters =
+
 
 # For "console" mode only
 [log.console]
 ;level =
 
+# log line format, valid options are text, console and json
+;format = console
+
 # For "file" mode only
 [log.file]
 ;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
 # This enables automated log rotate(switch of following options), default is true
 ;log_rotate = true
 
@@ -254,7 +317,7 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 ;max_lines = 1000000
 
 # Max size shift of single file, default is 28 means 1 << 28, 256MB
-;max_lines_shift = 28
+;max_size_shift = 28
 
 # Segment log daily, default is true
 ;daily_rotate = true
@@ -262,7 +325,24 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 # Expired days of log file(delete after max days), default is 7
 ;max_days = 7
 
-#################################### AMPQ Event Publisher ##########################
+[log.syslog]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
+
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
+
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
+
+
+#################################### AMQP Event Publisher ##########################
 [event_publisher]
 ;enabled = false
 ;rabbitmq_url = amqp://localhost/
@@ -272,3 +352,44 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 [dashboards.json]
 enabled = true
 path = /var/vcap/store/grafana/dashboards
+
+#################################### Alerting ######################################
+[alerting]
+# Makes it possible to turn off alert rule execution.
+;execute_alerts = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /api/metrics
+[metrics]
+# Disable / Enable internal metrics
+;enabled           = true
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Internal Grafana Metrics ##########################
+# Url used to to import dashboards directly from Grafana.net
+[grafana_net]
+;url = https://grafana.net
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav)
+;provider =
+
+[external_image_storage.s3]
+;bucket_url =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;username =
+;password =

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -152,7 +152,7 @@ admin_password = <%= p("grafana.admin_password") %>
 
 [snapshots]
 # snapshot sharing options
-;external_enabled = true
+external_enabled = <%= p("grafana.snapshots.external_enabled") %>
 ;external_snapshot_url = https://snapshots-origin.raintank.io
 ;external_snapshot_name = Publish to snapshot.raintank.io
 

--- a/packages/grafana/spec
+++ b/packages/grafana/spec
@@ -4,5 +4,5 @@ name: grafana
 dependencies: []
 
 files:
-- grafana/*.tar.gz # From https://grafanarel.s3.amazonaws.com/builds/grafana-4.0.0-1480439068.linux-x64.tar.gz
+- grafana/*.tar.gz # From https://grafanarel.s3.amazonaws.com/builds/grafana-4.1.2-1486989747.linux-x64.tar.gz
 - pid_utils.sh


### PR DESCRIPTION
With this PR an update to Grafana v4.1.2 is prepared. The following steps are needed to complete the update:
- download https://grafanarel.s3.amazonaws.com/builds/grafana-4.1.2-1486989747.linux-x64.tar.gz
- bosh add blob \<downloaded file> grafana
- bosh upload blobs
- bosh create release --final

The file config.ini.erb has been adapted to the current version of sample.ini (that is part of the downloaded Grafana release). Although no configuration properties have been changed, it makes it easier to merge future versions.

Furthermore the config property for external snapshot sharing has been exposed (defaults to true, but can now be disabled).
