### PR TITLE
Add support for generic OAuth

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -9,6 +9,9 @@ templates:
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt
+  client.key.erb: config/client.key
+  client.crt.erb: config/client.crt
+  cacert.pem.erb: config/cacert.pem
 
 packages:
 - grafana
@@ -137,6 +140,49 @@ properties:
   grafana.auth.google.allowed_email_domains:
     description: "E-mail address domains to allow. If empty, all are allowed."
     default: []
+
+  grafana.auth.generic_oauth.enabled:
+    description: "Permit users to authenticate via Generic OAuth."
+    default: false
+
+  grafana.auth.generic_oauth.name:
+    description: "Generic OAuth login link display name."
+    default: "OAuth"
+
+  grafana.auth.generic_oauth.client_id:
+    description: "Generic OAuth client ID."
+
+  grafana.auth.generic_oauth.client_secret:
+    description: "Generic OAuth client secret."
+
+  grafana.auth.generic_oauth.scopes:
+    description: "Generic OAuth scopes."
+
+  grafana.auth.generic_oauth.auth_url:
+    description: "Generic OAuth authorization endpoint."
+
+  grafana.auth.generic_oauth.token_url:
+    description: "Generic OAuth access token endpoint."
+
+  grafana.auth.generic_oauth.api_url:
+    description: "Generic OAuth OpenID UserInfo API endpoint."
+
+  grafana.auth.generic_oauth.allowed_domains:
+    description: "E-mail address domains to allow. If empty, all are allowed."
+    default: []
+
+  grafana.auth.generic_oauth.allow_sign_up:
+    description: "Permit users to register via Generic OAuth."
+    default: true
+
+  grafana.auth.generic_oauth.tls_client_cert:
+    description: "PEM encoded certificate for TLS client authentication via Generic OAuth."
+
+  grafana.auth.generic_oauth.tls_client_key:
+    description: "PEM encoded private key for TLS client authentication via Generic OAuth."
+
+  grafana.auth.generic_oauth.tls_client_ca:
+    description: "PEM encoded CA certificate for TLS client authentication via Generic OAuth."
 
   grafana.datasource:
     description: "Grafana datasource; see http://docs.grafana.org/http_api/data_source/ for details"

--- a/jobs/grafana/templates/cacert.pem.erb
+++ b/jobs/grafana/templates/cacert.pem.erb
@@ -1,0 +1,1 @@
+<%= p("grafana.auth.generic_oauth.tls_client_ca", "") %>

--- a/jobs/grafana/templates/client.crt.erb
+++ b/jobs/grafana/templates/client.crt.erb
@@ -1,0 +1,1 @@
+<%= p("grafana.auth.generic_oauth.tls_client_cert", "") %>

--- a/jobs/grafana/templates/client.key.erb
+++ b/jobs/grafana/templates/client.key.erb
@@ -1,0 +1,1 @@
+<%= p("grafana.auth.generic_oauth.tls_client_key", "") %>

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -227,19 +227,25 @@ api_url = <%= p("grafana.auth.google.api_url") %>
 allowed_domains = <%= p("grafana.auth.google.allowed_email_domains").join(" ") %>
 <% end %>
 
+<% if_p("grafana.auth.generic_oauth.enabled", "grafana.auth.generic_oauth.client_id", "grafana.auth.generic_oauth.client_secret", "grafana.auth.generic_oauth.auth_url", "grafana.auth.generic_oauth.token_url", "grafana.auth.generic_oauth.api_url") do %>
 #################################### Generic OAuth ##########################
 [auth.generic_oauth]
-;enabled = false
-;name = OAuth
-;allow_sign_up = true
-;client_id = some_id
-;client_secret = some_secret
-;scopes = user:email,read:org
-;auth_url = https://foo.bar/login/oauth/authorize
-;token_url = https://foo.bar/login/oauth/access_token
-;api_url = https://foo.bar/user
-;team_ids =
-;allowed_organizations =
+enabled = true
+name = <%= p("grafana.auth.generic_oauth.name") %>
+allow_sign_up = <%= p("grafana.auth.generic_oauth.allow_sign_up") %>
+client_id = <%= p("grafana.auth.generic_oauth.client_id") %>
+client_secret = <%= p("grafana.auth.generic_oauth.client_secret") %>
+scopes = <%= p("grafana.auth.generic_oauth.scopes").join(" ") %>
+auth_url = <%= p("grafana.auth.generic_oauth.auth_url") %>
+token_url = <%= p("grafana.auth.generic_oauth.token_url") %>
+api_url = <%= p("grafana.auth.generic_oauth.api_url") %>
+allowed_domains = <%= p("grafana.auth.generic_oauth.allowed_domains").join(" ") %>
+<% if_p("grafana.auth.generic_oauth.tls_client_cert", "grafana.auth.generic_oauth.tls_client_key", "grafana.auth.generic_oauth.tls_client_ca") do %>
+tls_client_cert = /var/vcap/jobs/grafana/config/client.crt
+tls_client_key = /var/vcap/jobs/grafana/config/client.key
+tls_client_ca = /var/vcap/jobs/grafana/config/cacert.pem
+<% end %>
+<% end %>
 
 #################################### Grafana.net Auth ####################
 [auth.grafananet]


### PR DESCRIPTION
expose grafana configuration options for auth.generic_oauth [1] in bosh deployment manifest 
this is useful e.g. if you want to use Cloudfoundry's UAA [2] as oauth provider

[1] http://docs.grafana.org/installation/configuration/#auth-generic-oauth
[2] https://github.com/cloudfoundry/uaa