### PR TITLE
update grafana to v4.4.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-grafana/grafana-4.2.0.linux-x64.tar.gz:
-  size: 45741731
-  object_id: dbfe6b77-ed7c-43f7-5240-69a30d8d9c69
-  sha: 58f0b6c01dc172113953cd4426ed34a8911ea1f0
+grafana/grafana-4.4.1.linux-x64.tar.gz:
+  size: 47275422
+  sha: 0acc15a09295ce1e7d09c97a096a031c76accdff

--- a/packages/grafana/spec
+++ b/packages/grafana/spec
@@ -4,5 +4,5 @@ name: grafana
 dependencies: []
 
 files:
-- grafana/*.tar.gz # From https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.2.0.linux-x64.tar.gz
+- grafana/*.tar.gz # From https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.4.1.linux-x64.tar.gz
 - pid_utils.sh


### PR DESCRIPTION
The following steps are needed to complete the update:

* wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.4.1.linux-x64.tar.gz
* bosh add blob <downloaded file> grafana
* bosh upload blobs
* bosh create release --final