### PR TITLE
Update Grafana to v4.5.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,0 @@
-grafana/grafana-4.4.1.linux-x64.tar.gz:
-  size: 47275422
-  object_id: 5eb5b55a-d878-4ade-5c92-66f112412d67
-  sha: 0acc15a09295ce1e7d09c97a096a031c76accdff

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -28,7 +28,7 @@ plugins = /var/vcap/store/grafana/plugins
 #
 #################################### Server ####################################
 [server]
-# Protocol (http or https)
+# Protocol (http, https, socket)
 protocol = <%= p("grafana.ssl.cert", nil) ? "https" : "http" %>
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -65,6 +65,9 @@ cert_file = /var/vcap/jobs/grafana/config/ssl.crt
 cert_key = /var/vcap/jobs/grafana/config/ssl.key
 <% end %>
 
+# Unix socket path
+;socket =
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password
@@ -88,6 +91,13 @@ type = sqlite3
 # For "sqlite3" only, path relative to data_path setting
 path = grafana.db
 
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
+# Max conn setting default is 0 (mean not set)
+;max_open_conn =
+
+
 #################################### Session ####################################
 [session]
 # Either "memory", "file", "redis", "mysql", "postgres", default is "file"
@@ -110,6 +120,13 @@ path = grafana.db
 # Session life time, default is 86400
 <% if_p("grafana.session.session_life_time") do |lifetime| %>session_life_time = <%= lifetime %><% end %>
 
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+
 #################################### Analytics ####################################
 [analytics]
 # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
@@ -122,7 +139,7 @@ reporting_enabled = false
 # for new vesions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists
 # This option does not cause any auto updates, nor send any information
-# only a GET request to http://grafana.net to get latest versions
+# only a GET request to http://grafana.com to get latest versions
 check_for_updates = false
 
 # Google Analytics universal tracking code, only enabled if you specify an id here
@@ -182,9 +199,17 @@ auto_assign_org_role = <%= p("grafana.users.auto_assign_organization_role") %>
 # Default UI theme ("dark" or "light")
 ;default_theme = dark
 
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
 [auth]
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
@@ -241,8 +266,8 @@ allowed_domains = <%= p("grafana.auth.google.allowed_email_domains").join(" ") %
 ;team_ids =
 ;allowed_organizations =
 
-#################################### Grafana.net Auth ####################
-[auth.grafananet]
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
 ;enabled = false
 ;allow_sign_up = true
 ;client_id = some_id
@@ -274,11 +299,13 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 ;enabled = false
 ;host = localhost:25
 ;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
 ;password =
 ;cert_file =
 ;key_file =
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
+;from_name = Grafana
 
 [emails]
 ;welcome_email_on_sign_up = false
@@ -289,7 +316,7 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 # Use space to separate multiple modes, e.g. "console file"
 ;mode = console file
 
-# Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
+# Either "debug", "info", "warn", "error", "critical", default is "info"
 ;level = info
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
@@ -353,9 +380,11 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 enabled = true
 path = /var/vcap/store/grafana/dashboards
 
-#################################### Alerting ######################################
+#################################### Alerting ############################
 [alerting]
-# Makes it possible to turn off alert rule execution.
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
 ;execute_alerts = true
 
 #################################### Internal Grafana Metrics ##########################
@@ -373,10 +402,10 @@ path = /var/vcap/store/grafana/dashboards
 ;address =
 ;prefix = prod.grafana.%(instance_name)s.
 
-#################################### Internal Grafana Metrics ##########################
-# Url used to to import dashboards directly from Grafana.net
-[grafana_net]
-;url = https://grafana.net
+#################################### Grafana.com integration  ##########################
+# Url used to to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
 
 #################################### External image storage ##########################
 [external_image_storage]

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -209,7 +209,9 @@ auto_assign_org_role = <%= p("grafana.users.auto_assign_organization_role") %>
 ;disable_login_form = false
 
 # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
-;disable_signout_menu = false
+<% if_p("grafana.auth.proxy.enabled") do %>
+disable_signout_menu = true
+<% end %>
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]

--- a/packages/grafana/spec
+++ b/packages/grafana/spec
@@ -4,5 +4,5 @@ name: grafana
 dependencies: []
 
 files:
-- grafana/*.tar.gz # From https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.4.1.linux-x64.tar.gz
+- grafana/*.tar.gz # From https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.5.1.linux-x64.tar.gz
 - pid_utils.sh


### PR DESCRIPTION
With this PR an update to Grafana v4.5.1 is prepared. The following steps are needed to complete the update:

- download https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.5.1.linux-x64.tar.gz
- bosh add blob <downloaded file> grafana
- bosh upload blobs
- bosh create release --final

The file config.ini.erb has been adapted to the current version of sample.ini (that is part of the downloaded Grafana release).

Furthermore the signout link is disabled when auth.proxy is used.
