### PR TITLE
Update config.ini and disable signout link

### DIFF
--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -28,7 +28,7 @@ plugins = /var/vcap/store/grafana/plugins
 #
 #################################### Server ####################################
 [server]
-# Protocol (http or https)
+# Protocol (http, https, socket)
 protocol = <%= p("grafana.ssl.cert", nil) ? "https" : "http" %>
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -65,6 +65,9 @@ cert_file = /var/vcap/jobs/grafana/config/ssl.crt
 cert_key = /var/vcap/jobs/grafana/config/ssl.key
 <% end %>
 
+# Unix socket path
+;socket =
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password
@@ -88,6 +91,13 @@ type = sqlite3
 # For "sqlite3" only, path relative to data_path setting
 path = grafana.db
 
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
+# Max conn setting default is 0 (mean not set)
+;max_open_conn =
+
+
 #################################### Session ####################################
 [session]
 # Either "memory", "file", "redis", "mysql", "postgres", default is "file"
@@ -110,6 +120,13 @@ path = grafana.db
 # Session life time, default is 86400
 <% if_p("grafana.session.session_life_time") do |lifetime| %>session_life_time = <%= lifetime %><% end %>
 
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+
 #################################### Analytics ####################################
 [analytics]
 # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
@@ -122,7 +139,7 @@ reporting_enabled = false
 # for new vesions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists
 # This option does not cause any auto updates, nor send any information
-# only a GET request to http://grafana.net to get latest versions
+# only a GET request to http://grafana.com to get latest versions
 check_for_updates = false
 
 # Google Analytics universal tracking code, only enabled if you specify an id here
@@ -182,9 +199,17 @@ auto_assign_org_role = <%= p("grafana.users.auto_assign_organization_role") %>
 # Default UI theme ("dark" or "light")
 ;default_theme = dark
 
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
 [auth]
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
@@ -247,8 +272,8 @@ tls_client_ca = /var/vcap/jobs/grafana/config/cacert.pem
 <% end %>
 <% end %>
 
-#################################### Grafana.net Auth ####################
-[auth.grafananet]
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
 ;enabled = false
 ;allow_sign_up = true
 ;client_id = some_id
@@ -280,11 +305,13 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 ;enabled = false
 ;host = localhost:25
 ;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
 ;password =
 ;cert_file =
 ;key_file =
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
+;from_name = Grafana
 
 [emails]
 ;welcome_email_on_sign_up = false
@@ -295,7 +322,7 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 # Use space to separate multiple modes, e.g. "console file"
 ;mode = console file
 
-# Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
+# Either "debug", "info", "warn", "error", "critical", default is "info"
 ;level = info
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
@@ -359,9 +386,11 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 enabled = true
 path = /var/vcap/store/grafana/dashboards
 
-#################################### Alerting ######################################
+#################################### Alerting ############################
 [alerting]
-# Makes it possible to turn off alert rule execution.
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
 ;execute_alerts = true
 
 #################################### Internal Grafana Metrics ##########################
@@ -379,10 +408,10 @@ path = /var/vcap/store/grafana/dashboards
 ;address =
 ;prefix = prod.grafana.%(instance_name)s.
 
-#################################### Internal Grafana Metrics ##########################
-# Url used to to import dashboards directly from Grafana.net
-[grafana_net]
-;url = https://grafana.net
+#################################### Grafana.com integration  ##########################
+# Url used to to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
 
 #################################### External image storage ##########################
 [external_image_storage]

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -209,7 +209,9 @@ auto_assign_org_role = <%= p("grafana.users.auto_assign_organization_role") %>
 ;disable_login_form = false
 
 # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
-;disable_signout_menu = false
+<% if_p("grafana.auth.proxy.enabled") do %>
+disable_signout_menu = true
+<% end %>
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]


### PR DESCRIPTION
- The file config.ini.erb has been adapted to the current version of sample.ini.
- The signout link is disabled when auth.proxy is used.
