### PR TITLE
Add ldap authentication config

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -74,6 +74,15 @@ properties:
     description: "The role to assume for anonymous users."
     default: Viewer
 
+  grafana.auth.ldap.enabled:
+    description: "Auth LDAP enable"
+
+  grafana.auth.ldap.config:
+    description: "LDAP configuration (toml)"
+    
+  grafana.auth.ldap.allow_sign_up:
+    description: "Auth LDAP allow sign up"
+
   grafana.auth.github.enabled:
     description: "Permit users to authenticate via GitHub OAuth."
     default: false

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -297,10 +297,12 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 ;enabled = true
 
 #################################### Auth LDAP ##########################
+<% if_p("grafana.auth.ldap.enabled") do %>
 [auth.ldap]
-;enabled = false
-;config_file = /etc/grafana/ldap.toml
-;allow_sign_up = true
+enabled = true
+config_file = /var/vcap/jobs/grafana/ldap.toml
+allow_sign_up = <%= p("grafana.auth.ldap.allow_sign_up") %>
+<% end %>
 
 #################################### SMTP / Emailing ##########################
 [smtp]
@@ -465,4 +467,3 @@ password = <%= pass %>
 [external_image_storage.gcs]
 ;key_file =
 ;bucket =
-

--- a/jobs/grafana/templates/ldap.toml.erb
+++ b/jobs/grafana/templates/ldap.toml.erb
@@ -1,0 +1,1 @@
+<%= p("grafana.auth.ldap.config", "") %>


### PR DESCRIPTION
# What

Adding support for ldap authentication

# How to test

Deploy Grafana and verify that you can login using LDAP